### PR TITLE
Enhance test dependencies and some test stuffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 vendor/
+tests/reports

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "illuminate/support": "6.*"
   },
   "require-dev": {
-      "phpunit/phpunit": "^6.5",
-      "mockery/mockery": "^0.9.9"
+      "phpunit/phpunit": "^9.0",
+      "mockery/mockery": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Test Suite">
@@ -20,7 +19,7 @@
         <log type="testdox-text" target="tests/reports/testdox.txt"/>
     </logging>
     <filter>
-        <whitelist processUncoveredFilesFromWhitList="true">
+        <whitelist>
             <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>

--- a/tests/CircuitBreakerTest.php
+++ b/tests/CircuitBreakerTest.php
@@ -7,9 +7,9 @@ use PHPUnit\Framework\TestCase;
 use DeGraciaMathieu\EasyBreaker\Breaker;
 use DeGraciaMathieu\EasyBreaker\CircuitBreaker;
 
-class CircuitBreakerTest extends TestCase 
+class CircuitBreakerTest extends TestCase
 {
-    /** 
+    /**
      * @test
      */
     public function process_with_break()
@@ -27,13 +27,13 @@ class CircuitBreakerTest extends TestCase
             });
 
 
-        $this->assertNotNull($results);        
-        $this->assertEquals(2, count($results)); 
-        $this->assertEquals($results[0], "it's realy broken."); 
-        $this->assertEquals($results[1], "it's realy realy broken."); 
+        $this->assertNotNull($results);
+        $this->assertCount(2, $results);
+        $this->assertEquals($results[0], "it's realy broken.");
+        $this->assertEquals($results[1], "it's realy realy broken.");
     }
 
-    /** 
+    /**
      * @test
      */
     public function process_without_break()
@@ -47,7 +47,7 @@ class CircuitBreakerTest extends TestCase
             });
 
 
-        $this->assertnull($results);        
+        $this->assertNull($results);
     }
 
     /**
@@ -71,5 +71,5 @@ class CircuitBreakerTest extends TestCase
             ->do(function(Exception $e) use($message) {
                 return $message;
             });
-    }    
+    }
 }


### PR DESCRIPTION
# Changed log
- To avoid `ReflectionType::__toString` deprecated on `php-7.4` during Travis CI build, it should require `^1.3` `mockery/mockery` version. And look at PR #5 to know more details.
- Since this package requires `php-7.4` version at least, it's good to upgrade PHPUnit version to `9.x`.
- Removing some attributes on `phpunit.xml` because these attribute settings are not allowed on PHPUnit `9.x` version.
The message is as follows:

```
PHPUnit 9.2.5 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 12:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Line 23:
  - Element 'whitelist', attribute 'processUncoveredFilesFromWhitList': The attribute 'processUncoveredFilesFromWhitList' is not allowed.

  Test results may not be as expected.
```
- Removing additional white spaces on some PHP files.
- Using `assertCount` assertion to assert expected count is same as result count.
- Fix `assertNull` assertion name.