### PR TITLE
Test enhancement for assertions and PHPUnit config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "illuminate/support": "6.*"
   },
   "require-dev": {
-      "phpunit/phpunit": "^6.5",
-      "mockery/mockery": "^0.9.9"
+      "phpunit/phpunit": "^9.0",
+      "mockery/mockery": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,27 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix=".php">tests/</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-html" target="tests/reports/report" lowUpperBound="35" highLowerBound="70"/>
-        <log type="testdox-text" target="tests/reports/testdox.txt"/>
-    </logging>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitList="true">
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+    <report>
+      <html outputDirectory="tests/reports/report" lowUpperBound="35" highLowerBound="70"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix=".php">tests/</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <testdoxText outputFile="tests/reports/testdox.txt"/>
+  </logging>
 </phpunit>

--- a/tests/CircuitBreakerTest.php
+++ b/tests/CircuitBreakerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DeGraciaMathieu\Clike\Tests;
+namespace DeGraciaMathieu\EasyBreaker\Tests;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +28,7 @@ class CircuitBreakerTest extends TestCase
 
 
         $this->assertNotNull($results);
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
         $this->assertEquals($results[0], "it's really broken.");
         $this->assertEquals($results[1], "it's really really broken.");
     }
@@ -47,7 +47,7 @@ class CircuitBreakerTest extends TestCase
             });
 
 
-        $this->assertnull($results);
+        $this->assertNull($results);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Fix assertions about `assertNull` and `assertCount`.
- Using the correct namespace to be `DeGraciaMathieu\EasyBreaker\Tests;`.
- Upgrading `PHPUnit` version and `Mockery` for `php-7.4` version.
- Using the `vendor/bin/phpunit --migrate-configuration` to migrate PHPUnit configuration and it can be compatible with `php-7.4` version.